### PR TITLE
Add dutch/nederlands (nl) translation of the airrohr instructions.

### DIFF
--- a/content/airrohr/nl/00-introduction.md
+++ b/content/airrohr/nl/00-introduction.md
@@ -1,0 +1,32 @@
+---
+title: Inleiding
+---
+> 🚧 Bouw je eigen doe-het-zelf sensor en word onderdeel van het wereldwijde open-data en burgermeetnetwerk. <br> Met airRohr kan je zelf luchtvervuiling meten.
+
+
+<img src="../docs/airrohr/particulate-matter-air-quality-sensor-kit.jpeg"/>
+
+### Boodschappenlijst
+##### Sensorkit
+* [Voorgeprogrammeerde sensorkit](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+
+##### Losse onderdelen
+* [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)
+* [SDS011 fijnstofsensor](http://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=sds011) 
+* BME280 6-PIN, temperatuur & luchtvochtigheid & luchtdruk
+  - [via Aliexpress](https://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20200308040440&SearchText=bme280+-5V+%2B3.3V)
+  - [via Nettgio](https://nettigo.eu/products/module-pressure-humidity-and-temperature-sensor-bosch-bme280)
+  - [via Berrybase](https://www.berrybase.de/bauelemente/sensoren-module/feuchtigkeit/bme680-breakout-board-4in1-sensor-f-252-r-temperatur-luftfeuchtigkeit-luftdruck-und-luftg-252-t)
+* [Kabeltjes](http://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=Dupont+cable+20cm+female-female)
+* [USB-kabel bijv.: platte 2m Micro-USB](https://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20200308040708&SearchText=micro+usb+flat+cable+2m)
+* [USB-voeding](https://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20200308040834&SearchText=single+micro+usb+eu+power+supply)
+* [Kabelbinders](https://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20200308040852&SearchText=cable+straps)
+* Flexibele slang, liefst **niet** doorzichtig, diameter 6 mm, lengte ongeveer 20cm, bouwmarkt
+* [Bescherming tegen weersinvloeden, Marley Silent HT Arc DN 75 87°](https://www.bauhaus.info/rohrsysteme/marley-ht-bogen-/p/13625028)
+
+
+<br>
+
+🙌 Goed, je hebt besloten de onderdelen online te kopen!
+De bezorging kan een aantal dagen tot drie weken duren.
+

--- a/content/airrohr/nl/01-firmware.md
+++ b/content/airrohr/nl/01-firmware.md
@@ -1,0 +1,58 @@
+---
+title: Driver & firmware
+---
+
+We hebben de firmware al voorbereid. Je hoeft alleen maar de drivers te installeren en je NodeMCU (ESP8266) te programmeren.
+
+Om met de ESP8266 te communiceren heb je usb2serial drivers voor je Operating Systeem.
+
+De seriele chip voor de NodeMCU v3 is meestal CH341, kijk op de achterkant van je NodeMCU voor de technische informatie.
+
+Kies de link die overeenkomt met het operating systeem van je computer.
+
+### Windows
+
+##### Drivers voor NodeMCU V2 (CP2102) voor Windows
+* [Windows 10](https://www.silabs.com/documents/public/software/CP210x_Universal_Windows_Driver.zip) - Windows 10 zou deze automatisch moeten kunnen downloaden
+* [Windows 7/8/8.1](https://www.silabs.com/documents/public/software/CP210x_Windows_Drivers.zip) - 32-bit versie - ondersteunt **niet** 64-bit
+
+##### Driver voor NodeMCU V3 (CH341) voor Windows
+* [Windows](http://www.wch.cn/downloads/file/5.html) - Windows 10 zou deze automatisch moeten kunnen downloaden
+
+##### Uitpakken van de gedownloade file voor Windows:
+* voor NodeMCU (ESP8266) V2: open de folder CP210x en dubbelklik op de applicatie CP210xVCPInstaller_x64 (of x86)
+* voor NodeMCU (ESP8266) V3: open de folder CH341SER en dubbelklik op de applicatie SETUP.
+
+---
+
+### MacOS
+
+#####  MacOS Drivers
+* [NodeMCU V2](https://www.silabs.com/documents/public/software/Mac_OSX_VCP_Driver.zip )
+* [NodeMCU V3](http://www.wch.cn/downloads/file/178.html) 
+
+#####  Uitpakken van de gedownloade file for MacOS.
+* voor V2: Unzip de folder CP210x en dubbelklik op de applicatie CP210xVCPInstaller_x64 (or x86)
+* voor V3: Unzip de folder CH341SER en dubbelklik op de applicatie SETUP.
+* Herstart je Mac
+
+---
+
+### Linux
+Er hoeven geen drivers te worden geinstalleerd. De chip zou direct ondersteund moeten worden (controleer met dmesg)
+
+---
+### Firmware Flasher 
+Ondersteuning voor verschillende Operating Systemen: Windows, MacOS en Linux.
+
+* [airRohr Flashing Tool](http://firmware.sensor.community/airrohr/flashing-tool/)
+* [Broncode](https://github.com/opendata-stuttgart/airrohr-firmware-flasher)
+
+Verbind de NodeMCU met je computer via een korte micro-USB kabel (kies een kabel korter dan 1 meter, anders faalt de installatie mogelijk). Kies `latest_en.bin` (of een versie voor een andere taal) en klik op “Upload”
+Wacht totdat het proces klaar is. Nu kunnen we de sensor in elkaar zetten.
+
+#### Linux: Zet rechten op uitvoerbaar
+Na de download moet je mogelijk de rechten nog op executable zetten. Dit kan je doen met het commando: `chmod o+x <download filename>` 
+<br>
+Met dank aan [Piotr, from Poland](https://dropbox.inf.re/) voor zijn hulp! 🙋‍♂️ 
+

--- a/content/airrohr/nl/02-assemble.md
+++ b/content/airrohr/nl/02-assemble.md
@@ -1,0 +1,79 @@
+---
+title: Montage
+---
+
+> ⚠️ **BELANGRIJK**
+Installeer eerst de firmware voordat je de sensor monteert
+See __firmware flasher__ section.
+
+### NodeMCU v3
+Let op: onze instructies gaan over versie 3 van de NodeMCU. Deze kan je herkennen aan de pinnen VU en G (zie tekening).
+
+<img src="../docs/airrohr-wiring-sds011-bme280.jpg" style="width:40%; margin-top: 3em"/>
+<small>Copyright: roman-minyaylov, MIT License</small>
+
+
+<img src="../docs/nodemcu-v3-bme280.jpeg" style="margin-top: 1em"/>
+
+##### Dit is hoe het eruit zou moeten zien wanneer je klaar bent
+
+
+### Aansluiten van de SDS011
+De pinnen zijn genummerd van RECHTS naar LINKS, zorg ervoor dat de kabels op de pinnen zitten, de meeste Dupont kabeltjes passen ook tussen de pinnen.
+```bash
+SDS011 Pin 1 -> Pin D1 / GPIO5
+SDS011 Pin 2 -> Pin D2 / GPIO4
+SDS011 Pin 3 -> GND
+SDS011 Pin 4 -> niet aangesloten
+SDS011 Pin 5 -> VU (NodeMCU v3) / VIN (NodeMCU v1,v2)
+SDS011 Pin 6 -> niet aangesloten
+SDS011 Pin 7 -> niet aangesloten
+```
+
+### Solderen van de BME280
+<img src="../docs/solder-a-bme-280.jpeg" style="width:49%; padding-right: 0.5em" class="items-center"/>
+<img src="../docs/solder-bme-280.jpeg" style="width:49%;">
+
+Verbind de pinheader met het BME280 bord. Soldeer deze vanaf de achterkant. De afstand tussen de pinnen is erg klein, dus weer geduldig en voorzichtig.  
+
+De truuk is om de soldeerbout tegen de pin te houden, deze op te warmen en dan de soldeer toe te voegen.  
+
+
+
+### Aansluiten van de BME280
+Pinnen zijn genummerd van LINKS naar RECHTS.
+```bash
+VIN -> Pin 3V3 (3.3V)
+GND->  GND/G
+SDA -> PIN D3
+SCL -> Pin D4
+```
+
+### Alles bij elkaar binden
+
+ ##### Bind de NodeMCU en de SDS011 samen
+<img src="../docs/tie-air-quality-sensor-together.jpeg"/>
+Gebruik een kabelbinder om de NodeMCU (ESP8266) en de SDS011-sensor aan elkaar te verbinden zodat de WiFi-antenne van de sensor afwijst
+
+ ##### Verbind de flexibele slang
+ <img src="../docs/sds011-with-tube.jpeg" style="width:49%; padding-right: 0.5em"/>
+ <img src="../docs/bme280-tied-to-tube.jpeg" style="width:49%;">
+ 
+* Verbind de flexibele slang aan de SDS011 sensor
+* Gebruik nog een kabelbinder om de BME280-temperatuursensor aan de slang te binden
+* Haal de USB-kabel door de pijp. Monteer de SDS011 met de NodeMCU naar boven wijzend en de ventilator naar beneden
+
+ 
+ ##### Stop de sensor in de pijp
+* Duw de onderdelen in de pijp, zodat ze stevig vast zitten
+* De USB-kabel, flexibele slang en de BME280 zouden uit de pijp moeten steken
+* Duw het andere pijpdeel op de eerste
+
+<img src="../docs/sds011-jammed-into-tube.jpeg"/>
+
+ ##### Afwerking
+* Positioneer de temperatuursensor op de flexibele slang, zodat deze bij het uiteinde van de pijp zit.
+* Knip de flexibele slang af aan het eind van de pijp
+* Optioneel: je kan de open einden van de pijp bedekken met een fijn gaas. Zo kan de lucht circuleren maar hou je insecten buiten.
+ 
+<img src="../docs/position-bme280.jpeg"/>

--- a/content/airrohr/nl/02-assemble.md
+++ b/content/airrohr/nl/02-assemble.md
@@ -13,7 +13,7 @@ Let op: onze instructies gaan over versie 3 van de NodeMCU. Deze kan je herkenne
 <small>Copyright: roman-minyaylov, MIT License</small>
 
 
-<img src="../docs/nodemcu-v3-bme280.jpeg" style="margin-top: 1em"/>
+<img src="../docs/airrohr/airrohr-wiring-sds011-bme280.jpg" style="width:40%; margin-top: 3em;display: block"/>
 
 ##### Dit is hoe het eruit zou moeten zien wanneer je klaar bent
 
@@ -31,8 +31,8 @@ SDS011 Pin 7 -> niet aangesloten
 ```
 
 ### Solderen van de BME280
-<img src="../docs/solder-a-bme-280.jpeg" style="width:49%; padding-right: 0.5em" class="items-center"/>
-<img src="../docs/solder-bme-280.jpeg" style="width:49%;">
+<img src="../docs/airrohr/solder-a-bme-280.jpeg" style="width:49%; padding-right: 0.5em" class="items-center"/>
+<img src="../docs/airrohr/solder-bme-280.jpeg" style="width:49%;">
 
 Verbind de pinheader met het BME280 bord. Soldeer deze vanaf de achterkant. De afstand tussen de pinnen is erg klein, dus weer geduldig en voorzichtig.  
 
@@ -52,12 +52,12 @@ SCL -> Pin D4
 ### Alles bij elkaar binden
 
  ##### Bind de NodeMCU en de SDS011 samen
-<img src="../docs/tie-air-quality-sensor-together.jpeg"/>
+<img src="../docs/airrohr/tie-air-quality-sensor-together.jpeg" style="display: block"/>
 Gebruik een kabelbinder om de NodeMCU (ESP8266) en de SDS011-sensor aan elkaar te verbinden zodat de WiFi-antenne van de sensor afwijst
 
  ##### Verbind de flexibele slang
- <img src="../docs/sds011-with-tube.jpeg" style="width:49%; padding-right: 0.5em"/>
- <img src="../docs/bme280-tied-to-tube.jpeg" style="width:49%;">
+<img src="../docs/airrohr/sds011-with-tube.jpeg" style="width:49%; padding-right: 0.5em"/>
+<img src="../docs/airrohr/bme280-tied-to-tube.jpeg" style="width:49%;">
  
 * Verbind de flexibele slang aan de SDS011 sensor
 * Gebruik nog een kabelbinder om de BME280-temperatuursensor aan de slang te binden
@@ -69,11 +69,11 @@ Gebruik een kabelbinder om de NodeMCU (ESP8266) en de SDS011-sensor aan elkaar t
 * De USB-kabel, flexibele slang en de BME280 zouden uit de pijp moeten steken
 * Duw het andere pijpdeel op de eerste
 
-<img src="../docs/sds011-jammed-into-tube.jpeg"/>
+<img src="../docs/airrohr/sds011-jammed-into-tube.jpeg"/>
 
  ##### Afwerking
 * Positioneer de temperatuursensor op de flexibele slang, zodat deze bij het uiteinde van de pijp zit.
 * Knip de flexibele slang af aan het eind van de pijp
 * Optioneel: je kan de open einden van de pijp bedekken met een fijn gaas. Zo kan de lucht circuleren maar hou je insecten buiten.
  
-<img src="../docs/position-bme280.jpeg"/>
+<img src="../docs/airrohr/position-bme280.jpeg"/>

--- a/content/airrohr/nl/03-configure.md
+++ b/content/airrohr/nl/03-configure.md
@@ -1,0 +1,31 @@
+---
+title: Configuratie
+---
+### Het unieke ID bepalen
+1. Sluit het station met de USB-kabel aan op een spanningsbron om de sensor aan te zetten.
+
+2. Het station zal proberen te verbinden met het geconfigureerde WiFi-netwerk. De eerste keer zal deze connectie falen en het station zal dan zelf een WiFi-netwerk opzetten met als naam `Particulate Matter ID` , `Feinstaubsensor-ID` of `airRohr-ID`. Hierbij is ID het zogenaamde **ChipID** (bijvoorbeeld 13597771). **Schrijf dit nummer op, je hebt dit later nodig voor registratie van de sensor**
+
+3. Verbind met je computer of smartphone naar het WiFi netwerk dat door het station is opgezet. Wacht totdat de verbinding tot stand is gebracht.<br>*Android*: Als de verbinding onmiddellijk wordt verbroken, moet je mogelijk de optie 'Smart network switch' onder 'Connection -> WiFi -> Advanced' deactiveren.
+
+4. Open je browser en typ in [http://192.168.4.1/](http://192.168.4.1/).
+
+> ⚠️ **Let op**  Het kan een paar pogingen duren voordat de NodeMCU met het WiFi thuisnetwerk verbindt. Probeer de stappen een aantal keer totdat het werkt en wees geduldig. Wanneer de configuratie van de sensor gelukt is, zal het WiFi-netwerk van het station niet langer actief zijn en de configuratie-pagina is niet langer bereikbaar op IP-adres 192.168.4.1
+
+### Het station configureren
+1. Vul op de 'Configuratie' pagina je SSID (naam van je WiFi-thuisnetwerk) en WiFi-wachtwoord in.
+
+2. Als je de aanbevolen fijnstofsensor (SDS011) gebruikt, zijn er geen verdere aanpassingen aan de configuratie nodig.
+
+3. Klik op de 'Opslaan en herstarten' knop. Het station zal herstarten en is niet langer toegankelijk op deze manier wanneer het met het WiFi-thuisnetwerk verbonden is.
+
+<br>
+
+![](../docs/airrohr_config_initial.png)
+<br>
+
+### Controleer dat het station juist is geconfigureerd
+Als je geen andere wijzigingen hebt gemaakt in de vorige stap, anders dan WiFi netwerkconfiguratie, zal de sensor nu starten met meten en uploaden van data. Je kan na ongeveer 10 minuten controleren dat alles juist werkt, door naar de volgende pagina's te gaan. Zoek op deze pagina's naar je ChipID (in het voorbeeld hierboven 13597771).
+
+ * [Sensordata](http://www.madavi.de/sensor/graph.php)
+ * [WiFi-signaaldata](http://www.madavi.de/sensor/signal.php)

--- a/content/airrohr/nl/04-register.md
+++ b/content/airrohr/nl/04-register.md
@@ -1,0 +1,18 @@
+---
+title: Registratie
+---
+
+### Maak een account
+
+Ga naar [devices.sensor.community](https://devices.sensor.community/) om een account te maken en onderdeel te worden van het open data netwerk.
+
+
+### Register je apparaat
+Wanneer je een account heb gemaakt en bent ingelogd, kan je je apparaat registreren. Vul het formulier in om je apparaat te registreren. Ga naar Home -> (Login) - Sensors -> Register new sensor
+
+* sensor ID is het ChipID van de ESP8266 (NodeMCU) dat je eerder hebt opgeschreven
+* je e-mailadres (wordt niet gepubliceerd)
+* je adres: straat en huisnummer, postcode and stad. Klik op "Lookup entered address" om de coordinaten in te stellen (deze worden afgerond). Controleer de positie van de speld, verander indien nodig
+* stel een persoonlijke sensornaam in om het makkelijker te maken om sensoren te onderscheiden als je meerdere sensoren hebt (tuin, sensor voor je moeder, ...)
+* de omgeving van het station - bijvoorbeeld hoogte boven de grond, aan de weg, verkeersdrukte, vrije veld en dergelijke
+

--- a/content/airrohr/nl/05-troubleshoot.md
+++ b/content/airrohr/nl/05-troubleshoot.md
@@ -25,7 +25,7 @@ Je kan zoeken op [ID] in de tekst op de pagina [https://www.madavi.de/sensor/gra
 * Verbind via USB met een computer en bekijk het log
     * Volg de tekst op de seriele interface met een serieel-terminalprogramma (Instellingen: baud 9600, 8N1)
         * Linux: screen, minicom, cutecom; Windows: Tera Term; MacOS: screen, minicom, ...
-        * mogelijk zijn geschikt usb2serial drivers nog steeds vereist, zie [https://github.com/opendata-stuttgart/meta/wiki/Firmware-einspielen](https://github.com/opendata-stuttgart/meta/wiki/Firmware-einspielen)
+        * mogelijk zijn geschikte usb2serial drivers nog steeds vereist, zie [https://github.com/opendata-stuttgart/meta/wiki/Firmware-einspielen](https://github.com/opendata-stuttgart/meta/wiki/Firmware-einspielen)
     * Hier zou je moeten kunnen zien wat de sensor aan het doen is (boot messages, WiFi-verbinding of AP, meten - pas na 3 minuten)
 
 ### Problemen met de elektronica?

--- a/content/airrohr/nl/05-troubleshoot.md
+++ b/content/airrohr/nl/05-troubleshoot.md
@@ -1,0 +1,36 @@
+---
+title: Foutzoeken
+---
+
+### Problemen met verzenden?
+Ga naar het volgende adres in je browser, gebruik je eigen IDs:
+https://www.madavi.de/sensor/graph.php?sensor=esp8266-[ID]-[sensor_type]
+
+Je kan zoeken op [ID] in de tekst op de pagina [https://www.madavi.de/sensor/graph.php](https://www.madavi.de/sensor/graph.php)
+
+* Is de sensor geregistreerd via [https://devices.sensor.community/](https://devices.sensor.community/) en is de sensor zichtbaar op de kaart?
+* Had je vroeger een zwak WiFi-signaal? Hier is het server-side signaallog: https://www.madavi.de/sensor/signal.php?sensor=esp8266-[ID]
+
+
+### Problemen met de USB-kabel?
+* Controleer de voeding: USB-kabel
+* Herstart (haal de voeding los, trek bijvoorbeeld de USB plug eruit)
+* Is de WiFi-configuratie OK? (de sensor verbindt met het geconfigureerde WiFi-netwerk) Zo niet:
+    * maakt de sensor een access-point aan (in de eerste 2-7 minuten na een herstart)?
+    * kijk of er een `airrohr-[ID]` WiFi-netwerk is opgezet. Dit kan 1-2 minuten duren na een herstart.
+* Controleer op je eigen router of de sensor is aangemeld op het netwerk, onthou het IP-adres
+    * je kan "Discovery" in de [flashtool](https://github.com/opendata-stuttgart/airrohr-firmware-flasher/) gebruiken
+    * zo ja: verbind naar de sensor via IP met een browser `http://[ip-van-de-sensor]/` , de webpagina zou moeten verschijnen
+    * zo niet: de ESP heeft problemen, bijvoorbeeld de voeding is niet toereikend, reboot-loop of iets dergelijks
+* Verbind via USB met een computer en bekijk het log
+    * Volg de tekst op de seriele interface met een serieel-terminalprogramma (Instellingen: baud 9600, 8N1)
+        * Linux: screen, minicom, cutecom; Windows: Tera Term; MacOS: screen, minicom, ...
+        * mogelijk zijn geschikt usb2serial drivers nog steeds vereist, zie [https://github.com/opendata-stuttgart/meta/wiki/Firmware-einspielen](https://github.com/opendata-stuttgart/meta/wiki/Firmware-einspielen)
+    * Hier zou je moeten kunnen zien wat de sensor aan het doen is (boot messages, WiFi-verbinding of AP, meten - pas na 3 minuten)
+
+### Problemen met de elektronica?
+* Haal de elektronica uit de behuizing en kijk wat er gebeurt
+* Controleer/vervang de voeding nogmaals
+    * knippert de ESP LED kort na een herstart?
+    * SDS011: is de rode LED/ventilator aan na een reboot?
+    * controleer/vervang de kabels naar de sensoren nogmaals


### PR DESCRIPTION
This adds the dutch/nederlands (nl) translation for the airrohr instructions.
I've used the same file names as the english translation.

This adds files in content/airrohr/nl, not sure if other references need to be updated too.