### PR TITLE
fix: links to sds011 bme280 in the documentation

### DIFF
--- a/content/airrohr/cz/00-introduction.md
+++ b/content/airrohr/cz/00-introduction.md
@@ -8,7 +8,7 @@ title: Úvod
 
 ### Nákupní seznam
 ##### Set všech součástek
-* [Set všech potřebných součástek včetně nahraného softwaru](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Set všech potřebných součástek včetně nahraného softwaru](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Jednotlivé komponenty
 * [Modul NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/da/00-introduction.md
+++ b/content/airrohr/da/00-introduction.md
@@ -8,7 +8,7 @@ title: Introduktion
 
 ### Indkøbsliste
 #### Sensorsæt
-* [Pre-flashed Sensor Kit](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Pre-flashed Sensor Kit](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 #### Enkelte komponenter
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/de/00-einleitung.md
+++ b/content/airrohr/de/00-einleitung.md
@@ -8,7 +8,7 @@ title: Einleitung
 
 ### Einkaufsliste
 ###### Sensor-Bausatz
-* [Vorgeflashtes Sensor-Kit](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Vorgeflashtes Sensor-Kit](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ###### Einzelne Komponenten
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/el/00-introduction.md
+++ b/content/airrohr/el/00-introduction.md
@@ -8,7 +8,7 @@ title: Εισαγωγή
 
 ### Λίστα αγορών
 ##### Κιτ αισθητήρων
-* [Pre-flashed Sensor Kit](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Pre-flashed Sensor Kit](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Μεμονωμένα εξαρτήματα
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/en/00-introduction.md
+++ b/content/airrohr/en/00-introduction.md
@@ -8,7 +8,7 @@ title: Introduction
 
 ### Shopping list
 ##### Sensor kit
-* [Pre-flashed Sensor Kit](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Pre-flashed Sensor Kit](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Single components
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/es/00-introduction.md
+++ b/content/airrohr/es/00-introduction.md
@@ -7,7 +7,7 @@ title: Introducción
 
 ### Lista de compras
 ##### Kit de sensores
-* [Kit de sensores predestinados](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Kit de sensores predestinados](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Componentes individuales
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/et/00-introduction.md
+++ b/content/airrohr/et/00-introduction.md
@@ -9,7 +9,7 @@ title: Sissejuhatus
 
 ### Ostunimekiri
 ##### Anduri komplekt
-* [Eelvälgustatud andurikomplekt](https://nettigo.euproductsluftdaten-org-pl-kit-sds011-bme280)
+* [Eelvälgustatud andurikomplekt](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Üksikud komponendid
 * [NodeMCU ESP8266 CPUWLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/fi/00-introduction.md
+++ b/content/airrohr/fi/00-introduction.md
@@ -9,7 +9,7 @@ title: Johdanto
 
 ### Ostoslista
 ##### Anturisarja
-* [esilämmitetty anturipaketti](https://nettigo.euproductsluftdaten-org-pl-kit-sds011-bme280)
+* [esilämmitetty anturipaketti](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Yksittäiset komponentit
 * [NodeMCU ESP8266 CPUWLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/fr/00-introduction.md
+++ b/content/airrohr/fr/00-introduction.md
@@ -8,7 +8,7 @@ title: Introduction
 
 ### Liste des composants
 ##### Détecteur en kit
-* [Kit avec micrologiciel préinstallé](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Kit avec micrologiciel préinstallé](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Composants individuels
 * [Platine NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/hu/00-introduction.md
+++ b/content/airrohr/hu/00-introduction.md
@@ -8,7 +8,7 @@ title: Bevezetés
 
 ### Vásárlási lista
 ##### Szenzor készlet
-* [Előre feltöltött érzékelőkészlet](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Előre feltöltött érzékelőkészlet](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Egyedi alkatrészek
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/it/00-introduction.md
+++ b/content/airrohr/it/00-introduction.md
@@ -44,7 +44,7 @@ Per il funzionamento quotidiano sono necessari:
 Il kit completo è venduto in Europa solo da un e-commerce polacco:
 
 * [Kit pre configurato in
-  inglese](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+  inglese](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 #### Componenti singoli
 

--- a/content/airrohr/ja/00-introduction.md
+++ b/content/airrohr/ja/00-introduction.md
@@ -8,7 +8,7 @@ title: Introduction
 
 ### Shopping list
 ##### センサーキット
-* [プリフラッシングセンサーキット](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [プリフラッシングセンサーキット](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### シングルコンポーネント
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/lt/00-introduction.md
+++ b/content/airrohr/lt/00-introduction.md
@@ -9,7 +9,7 @@ title: Įvadas
 
 ### Pirkinių sąrašas
 #### Jutiklio rinkinys
-* [Iš anksto įjungtas jutiklio rinkinys](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Iš anksto įjungtas jutiklio rinkinys](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 #### Atskiri komponentai
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/lv/00-introduction.md
+++ b/content/airrohr/lv/00-introduction.md
@@ -8,7 +8,7 @@ title: Ievads
 
 ### Iepirkumu saraksts
 ##### Sensora komplekts
-* [Iepriekš ielādēts sensora komplekts](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Iepriekš ielādēts sensora komplekts](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Atsevišķas sastāvdaļas
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/nl/00-introduction.md
+++ b/content/airrohr/nl/00-introduction.md
@@ -8,7 +8,7 @@ title: Inleiding
 
 ### Boodschappenlijst
 ##### Complete sets (rond de € 50)
-* [Voorgeprogrammeerde sensorkit](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Voorgeprogrammeerde sensorkit](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 * [Sensorkit met DHT22 en mini display, behuizing zelf nog toevoegen](https://www.tinytronics.nl/shop/nl/luchtwachters-delft-maak-zelf-een-fijnstofmeter-workshop-kit)
 
 ##### Losse onderdelen

--- a/content/airrohr/pl/00-introduction.md
+++ b/content/airrohr/pl/00-introduction.md
@@ -8,7 +8,7 @@ title: Introduction
 
 ### Lista zakupów
 ##### Zestaw czujników
-* [Zestaw czujników wstępnych](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Zestaw czujników wstępnych](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Pojedyncze komponenty
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/pt/00-introduction.md
+++ b/content/airrohr/pt/00-introduction.md
@@ -8,7 +8,7 @@ title: Introdução
 
 ### Lista de compras
 ##### Kit de sensores
-* [Kit de sensores predefinido](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Kit de sensores predefinido](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Componentes individuais
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/ro/00-introduction.md
+++ b/content/airrohr/ro/00-introduction.md
@@ -8,7 +8,7 @@ title: Introducere
 
 ### Lista de cumpărături
 ##### Kit senzor
-* [Kit de senzori pre-flashed](https://nettigo.euproductsluftdaten-org-pl-kit-sds011-bme280)
+* [Kit de senzori pre-flashed](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Componente unice
 * [NodeMCU ESP8266 CPUWLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/se/00-introduction.md
+++ b/content/airrohr/se/00-introduction.md
@@ -8,7 +8,7 @@ title: Introduktion
 
 ### Inköpslista
 ##### Sensorsats
-* [Förblinkat sensorsats](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Förblinkat sensorsats](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Enskilda komponenter
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/sk/00-introduction.md
+++ b/content/airrohr/sk/00-introduction.md
@@ -8,7 +8,7 @@ title: Úvod
 
 ### Nákupný zoznam
 ##### Set všetkých potrebných súčiastok
-* [Set všetkých potrebných súčiastok s už nahratým softvérom](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Set všetkých potrebných súčiastok s už nahratým softvérom](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Jednotlivé komponenty
 * [Modul NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/sl/00-introduction.md
+++ b/content/airrohr/sl/00-introduction.md
@@ -8,7 +8,7 @@ title: Uvod
 
 ### Nakupovalni seznam
 #### Komplet senzorjev
-* [Komplet senzorjev s prednapetostjo](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Komplet senzorjev s prednapetostjo](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 #### Posamezni sestavni deli
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/ua/00-introduction.md
+++ b/content/airrohr/ua/00-introduction.md
@@ -7,7 +7,7 @@ title: Вступ
 
 ### Список покупок
 ##### Комплект датчиків
-* [Набір попередньо прошитих датчиків](https://nettigo.eu/products/luftdaten-org-pl-kit-sds011-bme280)
+* [Набір попередньо прошитих датчиків](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 ##### Поодинокі компоненти
 * [NodeMCU ESP8266 CPU/WLAN](https://www.aliexpress.com/wholesale?groupsort=1&SortType=price_asc&SearchText=nodemcu+v3+esp8266+ch340)

--- a/content/airrohr/zh/00-introduction.md
+++ b/content/airrohr/zh/00-introduction.md
@@ -8,7 +8,7 @@ title: Introduction
 
 ### Shopping list
 ##### Sensor kit
-* [预闪式传感器套件](https://nettigo.euproductsluftdaten-org-pl-kit-sds011-bme280)
+* [预闪式传感器套件](https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition)
 
 
 ##### 单个组件


### PR DESCRIPTION
This pull request resolves https://github.com/opendata-stuttgart/sensor.community/issues/211 

I updated the links pointing to the old product page and also fixed the links for `et, fi, ro, zh` languages which were not valid links.

Now the links to
<img width="418" alt="image" src="https://user-images.githubusercontent.com/22365519/187869831-71532728-68bd-44ee-b651-553c57686676.png">

Should point to https://nettigo.eu/products/sensor-community-kit-sds011-bme280-english-language-harness-cable-edition